### PR TITLE
Add optional support for others conventions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,29 @@
 /**
  * Picks objects keys by applying a predicate function.
  * @param  {Function} predicate The function applied for each key.
- * @return {Function} Returns the partially applied function.
+ * @return {Object} Returns the objects key.
  */
-function pickKeysBy (predicate) {
-  return function (originalObject) {
-    return Object.keys(originalObject)
-      .reduce((finalObject, key) => {
-        predicate(key) && (finalObject[key] = originalObject[key]);
-        return finalObject;
-      },
-    {});
-  };
+function pickKeysBy (originalObject, predicate) {
+  return Object.keys(originalObject)
+    .reduce((finalObject, key) => {
+      predicate(key) && (finalObject[key] = originalObject[key]);
+      return finalObject;
+    },
+  {});
 }
 
-// Check if a given key starts with `_`.
-const _isNotPrivate = key => key[0] !== '_';
-const omitPrivateKeys = pickKeysBy(_isNotPrivate);
+const omitPrivateKeys = function (originalObject, convention) {
+  var newObj;
+  if (convention === undefined) {
+    newObj = pickKeysBy(originalObject, (key) => key[0] !== '_');// Check if a given key starts with `_`.
+  }
+  else if (convention instanceof RegExp) {
+    newObj = pickKeysBy(originalObject, (key) => !convention.test(key));//Check if key match with convention
+  }
+  else {
+    throw new Error('convention argument must be an instace of RegExp if defined');
+  }
+  return newObj;
+};
 
 module.exports = omitPrivateKeys;

--- a/index.js
+++ b/index.js
@@ -12,18 +12,14 @@ function pickKeysBy (originalObject, predicate) {
   {});
 }
 
-const omitPrivateKeys = function (originalObject, convention) {
-  var newObj;
+const omitPrivateKeys = function (convention) {
   if (convention === undefined) {
-    newObj = pickKeysBy(originalObject, (key) => key[0] !== '_');// Check if a given key starts with `_`.
+    return (originalObject) => pickKeysBy(originalObject, (key) => key[0] !== '_');// Check if a given key starts with `_`.
   }
   else if (convention instanceof RegExp) {
-    newObj = pickKeysBy(originalObject, (key) => !convention.test(key));//Check if key match with convention
+    return (originalObject) => pickKeysBy(originalObject, (key) => !convention.test(key));//Check if key match with convention
   }
-  else {
-    throw new Error('convention argument must be an instace of RegExp if defined');
-  }
-  return newObj;
-};
+  throw new Error('convention argument must be an instace of RegExp if defined');
+}
 
 module.exports = omitPrivateKeys;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,11 @@
 const test = require('tape');
-const omitPrivateKeys = require('../');
+const omitPrivateKeys = require('../')();
+const omitPrivateKeysNotExctd = require('../');
+
+test('omitPrivateKeysNotExctd must be defined', t => {
+  t.equal(typeof omitPrivateKeysNotExctd, 'function', 'should be a function');
+  t.end();
+});
 
 test('omitPrivateKeys must be defined', t => {
   t.equal(typeof omitPrivateKeys, 'function', 'should be a function');
@@ -11,7 +17,7 @@ test('if convention is defined and is not an instance of RegExp', t => {
   var wrongConventions = ['', 1, false, null, {}];
 
   wrongConventions.forEach(function (elm) {
-    t.throws(() => omitPrivateKeys(obj, elm), undefined, 'Should throw an error if convention is ' + typeof elm);
+    t.throws(() => omitPrivateKeysNotExctd(elm), undefined, 'Should throw an error if convention is ' + typeof elm);
   })
   t.end();
 });
@@ -19,7 +25,7 @@ test('if convention is defined and is not an instance of RegExp', t => {
 test('if convention is an instance of RegExp', t => {
     const obj = { a : 1, _b : 2 };
     // ok
-    t.doesNotThrow(() => omitPrivateKeys(obj, new RegExp('^\$\$')));
+    t.doesNotThrow(() => omitPrivateKeysNotExctd(/^\$\$/));
     t.end();
 });
 
@@ -67,6 +73,8 @@ test('if no convention passed should not clean keys containing `_` other positio
 });
 
 test('if convention is passed should clean keys that match the RegExp', t => {
+  const omitPrivateKeysConv = omitPrivateKeysNotExctd(/^\$\$/); //pass a convention
+
   const obj = {
     _foo: 'foo',
     $$bar: 'bar',
@@ -76,7 +84,8 @@ test('if convention is passed should clean keys that match the RegExp', t => {
     c: true,
     $$cuba : 1
   };
-  const actual = omitPrivateKeys(obj, /^\$\$/);
+
+  const actual = omitPrivateKeysConv(obj);
 
   const expected = {
     _foo: 'foo',
@@ -90,5 +99,51 @@ test('if convention is passed should clean keys that match the RegExp', t => {
     actual, expected,
     'should return a object without keys matched by `/^\\$\\$/`'
   );
+  t.end();
+});
+
+test('if lib() is used more than once', t => {
+  const omitPrivateKeysWithDefault = omitPrivateKeysNotExctd();
+  const omitPrivateKeysConv = omitPrivateKeysNotExctd(/^\$\$/); //pass a convention
+  const obj = {
+    _foo : 1,
+     bar : 2,
+     $$cuba : 3
+  };
+
+  const expected = {
+    bar : 2,
+    $$cuba : 3
+  };
+
+  const expectedIfConvention = {
+    _foo: 1,
+    bar : 2
+  };
+
+  t.deepEqual(
+    omitPrivateKeysWithDefault(obj), expected,
+    'should Work  with only 1 parameter: the Object'
+  );
+
+  t.deepEqual(
+    omitPrivateKeysConv(obj), expectedIfConvention,
+    'if passed a convention : should Work  with only 1 parameter: the Object'
+  );
+
+  var i = 1;
+  while (i <= 3) {
+    t.deepEqual(
+      omitPrivateKeysWithDefault(obj), expected,
+      'should work the same function more than once: ' + i
+    );
+
+    t.deepEqual(
+      omitPrivateKeysConv(obj), expectedIfConvention,
+      'if passed a convention : should work the same function more than once: ' + i
+    );
+    i++;
+  }
+
   t.end();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,7 +6,24 @@ test('omitPrivateKeys must be defined', t => {
   t.end();
 });
 
-test('should clean keys preceeded with `_`', t => {
+test('if convention is defined and is not an instance of RegExp', t => {
+  const obj = { a : 1, _b : 2 };
+  var wrongConventions = ['', 1, false, null, {}];
+
+  wrongConventions.forEach(function (elm) {
+    t.throws(() => omitPrivateKeys(obj, elm), undefined, 'Should throw an error if convention is ' + typeof elm);
+  })
+  t.end();
+});
+
+test('if convention is an instance of RegExp', t => {
+    const obj = { a : 1, _b : 2 };
+    // ok
+    t.doesNotThrow(() => omitPrivateKeys(obj, new RegExp('^\$\$')));
+    t.end();
+});
+
+test('if no convention passed should clean keys preceeded with `_`', t => {
   const obj = {
     _foo: 'foo',
     _bar: 'bar',
@@ -28,7 +45,7 @@ test('should clean keys preceeded with `_`', t => {
   t.end();
 });
 
-test('should not clean keys containing `_` other positions than start', t => {
+test('if no convention passed should not clean keys containing `_` other positions than start', t => {
   // Disable eslint rule for this test only.
   /* eslint camelcase:[0] */
   const obj = {
@@ -45,6 +62,33 @@ test('should not clean keys containing `_` other positions than start', t => {
   t.deepEqual(
     actual, expected,
     'should return a object with keys containing `_`'
+  );
+  t.end();
+});
+
+test('if convention is passed should clean keys that match the RegExp', t => {
+  const obj = {
+    _foo: 'foo',
+    $$bar: 'bar',
+    bar$$ : 'isFine',
+    a: 2,
+    b: 'b',
+    c: true,
+    $$cuba : 1
+  };
+  const actual = omitPrivateKeys(obj, /^\$\$/);
+
+  const expected = {
+    _foo: 'foo',
+    bar$$ : 'isFine',
+    a: 2,
+    b: 'b',
+    c: true
+  };
+
+  t.deepEqual(
+    actual, expected,
+    'should return a object without keys matched by `/^\\$\\$/`'
   );
   t.end();
 });


### PR DESCRIPTION
Allow to set an **optional** parameter :bomb: (RegExp) to match others "private" keys 
